### PR TITLE
Systemd unit file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,5 @@ gradle-app.setting
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
 
-#dont commit the systemd unit to repo, end user might 
-not be running systemd
+#dont commit the systemd unit to repo, end user might not be running systemd
 signald.service

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ gradle-app.setting
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+#dont commit the systemd unit to repo, end user might 
+not be running systemd
+signald.service

--- a/gradlew
+++ b/gradlew
@@ -44,6 +44,21 @@ die ( ) {
     exit 1
 }
 
+# make a systemd unit file to peristantly start signald at boot
+function make_systemd_unit_file {
+
+    #get path to executable
+    location=$(pwd)/build/install/signald/bin/signald
+
+    echo "[Unit]" >> signald.service
+    echo "Description=Autostart signald" >> signald.service
+    echo "[Service]" >> signald.service
+    echo "Type=simple" >> signald.service
+    echo "ExecStart=${location} /tmp/signald.sock" >> signald.service
+    echo "[Install]" >> signald.service
+    echo "Alias=signald" >> signald.service
+}
+
 # OS specific support (must be 'true' or 'false').
 cygwin=false
 msys=false
@@ -167,6 +182,11 @@ eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$A
 # by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
 if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
   cd "$(dirname "$0")"
+fi
+
+if [ "$(uname)" == 'Linux' ]
+then
+   make_systemd_unit_file
 fi
 
 exec "$JAVACMD" "$@"

--- a/gradlew
+++ b/gradlew
@@ -186,7 +186,8 @@ fi
 
 if [ "$(uname)" == 'Linux' ]
 then
-   make_systemd_unit_file
+    make_systemd_unit_file
 fi
 
 exec "$JAVACMD" "$@"
+echo "In order to use the systemd unit file either cp or mv signald.service to /etc/systemd/system/"

--- a/gradlew
+++ b/gradlew
@@ -187,7 +187,8 @@ fi
 if [ "$(uname)" == 'Linux' ]
 then
     make_systemd_unit_file
+    echo "In order to use systemd unit file, cp or mv signald.service to /etc/systemd/system/"
+    echo
 fi
 
 exec "$JAVACMD" "$@"
-echo "In order to use the systemd unit file either cp or mv signald.service to /etc/systemd/system/"

--- a/signald.service
+++ b/signald.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Autostart signald
+[Service]
+Type=simple
+ExecStart=/home/netkitteh/projects/signald/build/install/signald/bin/signald /tmp/signald.sock
+[Install]
+Alias=signald

--- a/signald.service
+++ b/signald.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Autostart signald
-[Service]
-Type=simple
-ExecStart=/home/netkitteh/projects/signald/build/install/signald/bin/signald /tmp/signald.sock
-[Install]
-Alias=signald


### PR DESCRIPTION
Given the nature of the application I figured it would be a useful feature to generate a unit file on build that can be used to run the application from its build directory. the unit file runs signald with a default socket of /tmp/signald.sock