### PR TITLE
Allow quoted JSON strings to be de-serialised

### DIFF
--- a/src/main/java/io/finn/signald/JsonRequest.java
+++ b/src/main/java/io/finn/signald/JsonRequest.java
@@ -18,6 +18,12 @@
 package io.finn.signald;
 
 import java.util.List;
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 class JsonRequest {
     public String type;
@@ -36,4 +42,11 @@ class JsonRequest {
     public String avatar;
 
     JsonRequest() {}
+    @JsonCreator
+    public static JsonRequest Create(String jsonString) throws JsonParseException, JsonMappingException, IOException {
+        ObjectMapper mapper = new ObjectMapper();
+	JsonRequest request = null;
+	request = mapper.readValue(jsonString, JsonRequest.class);
+	return request;
+    }
 }

--- a/src/main/java/io/finn/signald/JsonRequest.java
+++ b/src/main/java/io/finn/signald/JsonRequest.java
@@ -45,8 +45,8 @@ class JsonRequest {
     @JsonCreator
     public static JsonRequest Create(String jsonString) throws JsonParseException, JsonMappingException, IOException {
         ObjectMapper mapper = new ObjectMapper();
-	JsonRequest request = null;
-	request = mapper.readValue(jsonString, JsonRequest.class);
-	return request;
+        JsonRequest request = null;
+        request = mapper.readValue(jsonString, JsonRequest.class);
+        return request;
     }
 }


### PR DESCRIPTION
Thanks a lot for this very nice library, @thefinn93 !
This PR fixes a `Can not instantiate value of type [...] from String value; no single-String constructor/factory method` `com.fasterxml.jackson.databind.JsonMappingException` encountered during the de-serialisation of a `JsonRequest` on my setup.
It introduces a static factory method exposed to `jackson` through a `@JsonCreator` attribute (thus imposing a new set of imports already used elsewhere.