### PR TITLE
allow adding members without profile key to groups

### DIFF
--- a/src/main/java/io/finn/signald/clientprotocol/v1/UpdateGroupRequest.java
+++ b/src/main/java/io/finn/signald/clientprotocol/v1/UpdateGroupRequest.java
@@ -114,13 +114,9 @@ public class UpdateGroupRequest implements RequestType<GroupInfo> {
         for (JsonAddress member : addMembers) {
           Recipient recipient = recipientsTable.get(member);
           ProfileKeyCredential profileKeyCredential = a.getDB().ProfileKeysTable.getProfileKeyCredential(recipient);
-          if (profileKeyCredential == null) {
-            logger.warn("failed to add group member with no profile");
-            continue;
-          }
           recipients.add(recipientsTable.get(recipient.getAddress()));
           UUID uuid = recipient.getUUID();
-          candidates.add(new GroupCandidate(uuid, Optional.of(profileKeyCredential)));
+          candidates.add(new GroupCandidate(uuid, Optional.ofNullable(profileKeyCredential)));
         }
         change = groupOperations.createModifyGroupMembershipChange(candidates, Set.of(), a.getUUID());
       } else if (removeMembers != null && removeMembers.size() > 0) {


### PR DESCRIPTION
I'm not entirely sure whether this works because I ran into some seemingly unrelated issues when creating the account I tried it with.
It seems I can invite users to groups and they will appear in `pendingMembers`, but they may not receive an invitation. Maybe you can give this a try and see if you can reproduce it?